### PR TITLE
Update top-languages-fetcher.js

### DIFF
--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -27,7 +27,7 @@ const fetcher = (variables, token) => {
       query userInfo($login: String!) {
         user(login: $login) {
           # fetch only owner repos & not forks
-          repositories(ownerAffiliations: OWNER, isFork: false, first: 100) {
+          repositories(ownerAffiliations: OWNER, isFork: false, first: 100, isArchived: false) {
             nodes {
               name
               languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {


### PR DESCRIPTION
By add new feature of `isArchived` then use on the URL as `&exclude repo=isArchived` will ignore all the Archived repos languages count. 

This just personal needed, maybe someone could use it